### PR TITLE
fix: lua-circuit-breaker version to 1.0.2

### DIFF
--- a/kong-circuit-breaker-1.0.3-1.rockspec
+++ b/kong-circuit-breaker-1.0.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
     "lua >= 5.1",
-    "lua-circuit-breaker >= 1.0.3",
+    "lua-circuit-breaker >= 1.0.2",
 }
 
 build = {


### PR DESCRIPTION
### Summary

Fix version for lua-circuit-breaker library. Bump rockspec version CI actions wrongly increased the version of this dependency also from 1.0.2 to 1.0.3 also since it finds and replaces using version number only.
