### PR TITLE
Fix non-existent method name

### DIFF
--- a/kong/plugins/circuit-breaker/handler.lua
+++ b/kong/plugins/circuit-breaker/handler.lua
@@ -120,11 +120,11 @@ function CircuitBreakerHandler:init_worker()
 			local route_id = key_parts[3]
 
 			if route_id ~= "" then
-				circuit_breakers:remove_breakers_by_level(route_id) -- Route level circuit breaker
+				circuit_breakers:remove_breakers_by_group(route_id) -- Route level circuit breaker
 			elseif service_id ~= "" then
-				circuit_breakers:remove_breakers_by_level(service_id) -- Service level circuit breaker
+				circuit_breakers:remove_breakers_by_group(service_id) -- Service level circuit breaker
 			else
-				circuit_breakers:remove_breakers_by_level("global") -- Global circuit breaker
+				circuit_breakers:remove_breakers_by_group("global") -- Global circuit breaker
 			end
 
 			local cache_key = kong.db.plugins:cache_key("circuit_breaker_excluded_apis", service_id, route_id)


### PR DESCRIPTION
### Summary

There was a code that referred to a non-existent method name. 
In the current version 1.0.4, the following error occurs.
```
2021/08/17 04:51:11 [error] 35#0: *3100 [lua] events.lua:194: do_handlerlist(): worker-events: event callback failed; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=35 error='...l/share/lua/5.1/kong/plugins/circuit-breaker/handler.lua:127: attempt to call method 'remove_breakers_by_level' (a nil value)
stack traceback:
 ...l/share/lua/5.1/kong/plugins/circuit-breaker/handler.lua:127: in function <...l/share/lua/5.1/kong/plugins/circuit-breaker/handler.lua:109>
 [C]: in function 'xpcall'
 /usr/local/share/lua/5.1/resty/worker/events.lua:185: in function 'do_handlerlist'
 /usr/local/share/lua/5.1/resty/worker/events.lua:219: in function 'do_event_json'
 /usr/local/share/lua/5.1/resty/worker/events.lua:361: in function 'post'
 /usr/local/share/lua/5.1/kong/cache/init.lua:113: in function 'broadcast'
 /usr/local/share/lua/5.1/resty/mlcache.lua:1324: in function 'delete'
 /usr/local/share/lua/5.1/kong/cache/init.lua:232: in function 'invalidate_local'
 /usr/local/share/lua/5.1/kong/cache/init.lua:244: in function 'invalidate'
 /usr/local/share/lua/5.1/kong/runloop/handler.lua:371: in function </usr/local/share/lua/5.1/kong/runloop/handler.lua:353>
 ```
So I have fixed it to the correct name.