### PR TITLE
chore: fix lua-circuit-breaker dependency version

### DIFF
--- a/kong-circuit-breaker-1.0.4-1.rockspec
+++ b/kong-circuit-breaker-1.0.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
     "lua >= 5.1",
-    "lua-circuit-breaker >= 1.0.2",
+    "lua-circuit-breaker == 1.0.2",
 }
 
 build = {


### PR DESCRIPTION
### Summary

Fix lua-circuit-breaker dependency version from >=1.0.2 to == 1.0.2