### PR TITLE
feat: configure circuit-breaker based on consumer_id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  KONG_VERSION: 2.2.0
+  KONG_VERSION: 3.9.x
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -30,7 +30,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
 
       - name: Checkout github branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/draft-and-bump.yml
+++ b/.github/workflows/draft-and-bump.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - id: release-drafter
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout repo
       # If target branch is "master" and PR has label "publish", only then run this step
       if: ${{ steps.check-publish-label.outputs.result == 'true' && github.ref == 'refs/heads/master' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.COMMIT_ACCESS_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - run: .ci/scripts/install-deps.sh
     - run: .ci/scripts/upload.sh ${{ secrets.LUAROCKS_KEY }}

--- a/kong/plugins/circuit-breaker/handler.lua
+++ b/kong/plugins/circuit-breaker/handler.lua
@@ -27,12 +27,6 @@ end
 
 -- Return circuit breaker instance for this API
 local function get_circuit_breaker(conf, api_identifier)
-    local consumer = kong.client.get_consumer()
-    local consumer_id
-    if consumer ~= nil then
-        consumer_id = consumer.id
-    end
-
     local cb_table_key = "global"
     if conf.route_id ~= nil then
         cb_table_key = conf.route_id
@@ -40,8 +34,8 @@ local function get_circuit_breaker(conf, api_identifier)
         cb_table_key = conf.service_id
     end
 
-    if consumer_id ~= nil then
-        cb_table_key = consumer_id .. "_" .. cb_table_key
+    if conf.consumer_id ~= nil then
+        cb_table_key = conf.consumer_id .. "_" .. cb_table_key
     end
 
     return circuit_breakers:get_circuit_breaker(api_identifier, cb_table_key, conf)
@@ -136,16 +130,16 @@ function CircuitBreakerHandler:init_worker()
                 return
             end
 
-            local consumer_id = key_parts[5]
-            local service_id = key_parts[4]
             local route_id = key_parts[3]
+            local service_id = key_parts[4]
+            local consumer_id = key_parts[5]
 
-            local group_prefix
-            if consumer_id~= nil then
-                group_prefix = consumer_id .. "_"
+            local group_prefix, group_suffix
+
+            if consumer_id ~= "" then
+                group_prefix = consumer_id
             end
 
-            local group_suffix
             if route_id ~= "" then
                 group_suffix = route_id -- Route level circuit breaker
             elseif service_id ~= "" then
@@ -154,8 +148,8 @@ function CircuitBreakerHandler:init_worker()
                 group_suffix = "global" -- Global circuit breaker
             end
 
-            if group_prefix~=nil then
-                circuit_breakers:remove_breakers_by_group(group_prefix .. group_suffix)
+            if group_prefix ~= nil then
+                circuit_breakers:remove_breakers_by_group(group_prefix .. "_" .. group_suffix)
             else
                 circuit_breakers:remove_breakers_by_group(group_suffix)
             end

--- a/kong/plugins/circuit-breaker/handler.lua
+++ b/kong/plugins/circuit-breaker/handler.lua
@@ -27,11 +27,21 @@ end
 
 -- Return circuit breaker instance for this API
 local function get_circuit_breaker(conf, api_identifier)
+    local consumer = kong.client.get_consumer()
+    local consumer_id
+    if consumer ~= nil then
+        consumer_id = consumer.id
+    end
+
     local cb_table_key = "global"
     if conf.route_id ~= nil then
         cb_table_key = conf.route_id
     elseif conf.service_id ~= nil then
         cb_table_key = conf.service_id
+    end
+
+    if consumer_id ~= nil then
+        cb_table_key = consumer_id .. "_" .. cb_table_key
     end
 
     return circuit_breakers:get_circuit_breaker(api_identifier, cb_table_key, conf)
@@ -126,18 +136,31 @@ function CircuitBreakerHandler:init_worker()
                 return
             end
 
+            local consumer_id = key_parts[5]
             local service_id = key_parts[4]
             local route_id = key_parts[3]
 
-            if route_id ~= "" then
-                circuit_breakers:remove_breakers_by_group(route_id) -- Route level circuit breaker
-            elseif service_id ~= "" then
-                circuit_breakers:remove_breakers_by_group(service_id) -- Service level circuit breaker
-            else
-                circuit_breakers:remove_breakers_by_group("global") -- Global circuit breaker
+            local group_prefix
+            if consumer_id~= nil then
+                group_prefix = consumer_id .. "_"
             end
 
-            local cache_key = kong.db.plugins:cache_key("circuit_breaker_excluded_apis", service_id, route_id)
+            local group_suffix
+            if route_id ~= "" then
+                group_suffix = route_id -- Route level circuit breaker
+            elseif service_id ~= "" then
+                group_suffix = service_id  -- Service level circuit breaker
+            else
+                group_suffix = "global" -- Global circuit breaker
+            end
+
+            if group_prefix~=nil then
+                circuit_breakers:remove_breakers_by_group(group_prefix .. group_suffix)
+            else
+                circuit_breakers:remove_breakers_by_group(group_suffix)
+            end
+
+            local cache_key = kong.db.plugins:cache_key("circuit_breaker_excluded_apis", service_id, route_id, consumer_id)
             kong.core_cache:invalidate(cache_key, false)
         end,
         "mlcache",

--- a/kong/plugins/circuit-breaker/helpers.lua
+++ b/kong/plugins/circuit-breaker/helpers.lua
@@ -5,8 +5,13 @@ local kong = kong
 local function get_excluded_apis(conf)
     local service_id = conf.service_id
     local route_id = conf.route_id
+    local consumer = kong.client.get_consumer()
+    local consumer_id
+    if consumer ~= nil then
+        consumer_id = consumer.id
+    end
 
-    local cache_key = kong.db.plugins:cache_key("circuit_breaker_excluded_apis", service_id, route_id)
+    local cache_key = kong.db.plugins:cache_key("circuit_breaker_excluded_apis", service_id, route_id, consumer_id)
     local excluded_apis, err = kong.core_cache:get(cache_key,
                                                     nil,
                                                     function(c) return cjson.decode(c["excluded_apis"]) end,

--- a/kong/plugins/circuit-breaker/helpers.lua
+++ b/kong/plugins/circuit-breaker/helpers.lua
@@ -5,11 +5,7 @@ local kong = kong
 local function get_excluded_apis(conf)
     local service_id = conf.service_id
     local route_id = conf.route_id
-    local consumer = kong.client.get_consumer()
-    local consumer_id
-    if consumer ~= nil then
-        consumer_id = consumer.id
-    end
+    local consumer_id = conf.consumer_id
 
     local cache_key = kong.db.plugins:cache_key("circuit_breaker_excluded_apis", service_id, route_id, consumer_id)
     local excluded_apis, err = kong.core_cache:get(cache_key,

--- a/kong/plugins/circuit-breaker/schema.lua
+++ b/kong/plugins/circuit-breaker/schema.lua
@@ -19,9 +19,6 @@ return {
     name = "circuit-breaker",
     fields = {
         {
-            consumer = typedefs.no_consumer,
-        },
-        {
             protocols = typedefs.protocols_http,
         },
         {

--- a/spec/circuit-breaker/01-access_spec.lua
+++ b/spec/circuit-breaker/01-access_spec.lua
@@ -32,25 +32,78 @@ for _, strategy in ipairs(strategies) do
             excluded_apis = excluded_apis,
         }
 
-        local bp, db = helpers.get_db_utils(strategy, {"routes", "services", "plugins"}, {"circuit-breaker"});
+        local consumer_a_cb_config = {
+            min_calls_in_window = min_calls_in_window,
+            window_time = window_time,
+            api_call_timeout_ms = api_call_timeout_ms,
+            failure_percent_threshold = failure_percent_threshold,
+            wait_duration_in_open_state = wait_duration_in_open_state,
+            wait_duration_in_half_open_state = wait_duration_in_half_open_state,
+            half_open_max_calls_in_window = half_open_max_calls_in_window,
+            half_open_min_calls_in_window = half_open_min_calls_in_window,
+            error_status_code = 598, -- Different error code for consumer A
+            excluded_apis = excluded_apis,
+        }
 
-        assert(bp.routes:insert({
+        local bp, db = helpers.get_db_utils(strategy, {"routes", "services", "plugins", "consumers", "keyauth_credentials"}, {"circuit-breaker", "key-auth"});
+
+        local service = assert(bp.services:insert(
+            {
+                protocol = "http",
+                host = mock_host, -- Just a dummy value. Not honoured
+                port = mock_port, -- Just a dummy value. Not honoured
+                name = "test",
+                connect_timeout = 1000,
+                read_timeout = 1000,
+                write_timeout = 1000,
+                retries = 0
+            }))
+
+        local route = assert(bp.routes:insert({
             methods = {"GET"},
             protocols = {"http"},
             paths = {"/test"},
             strip_path = false,
             preserve_host = true,
-            service = bp.services:insert(
-                {
-                    protocol = "http",
-                    host = mock_host, -- Just a dummy value. Not honoured
-                    port = mock_port, -- Just a dummy value. Not honoured
-                    name = "test",
-                    connect_timeout = 1000,
-                    read_timeout = 1000,
-                    write_timeout = 1000,
-                    retries = 0
-                })
+            service = service
+        }))
+
+        local route2 = assert(bp.routes:insert({
+            methods = {"GET"},
+            protocols = {"http"},
+            paths = {"/test2"},
+            strip_path = false,
+            preserve_host = true,
+            service = service
+        }))
+
+        -- Create consumers for testing consumer-level circuit breakers
+        local consumer_a = assert(bp.consumers:insert({
+            username = "consumer_a",
+            custom_id = "consumer_a_id"
+        }))
+
+        local consumer_b = assert(bp.consumers:insert({
+            username = "consumer_b", 
+            custom_id = "consumer_b_id"
+        }))
+
+        -- Create API key credentials for consumers
+        local key_auth_a = assert(bp.keyauth_credentials:insert({
+            consumer = consumer_a,
+            key = "key_a"
+        }))
+
+        local key_auth_b = assert(bp.keyauth_credentials:insert({
+            consumer = consumer_b,
+            key = "key_b"
+        }))
+
+        -- Enable key-auth plugin on the route for consumer authentication
+        local key_auth_plugin = assert(bp.plugins:insert({
+            name = "key-auth",
+            route = route2,
+            config = {}
         }))
 
         local circuit_breaker_plugin = bp.plugins:insert{
@@ -58,24 +111,44 @@ for _, strategy in ipairs(strategies) do
             config = default_config
         }
 
-        local get_and_assert = function (res_status_to_be_generated, res_status_expected, put_delay)
+        -- Consumer-specific circuit breaker plugin for consumer_a with different config
+        local consumer_a_cb_plugin = bp.plugins:insert{
+            name = "circuit-breaker",
+            consumer = consumer_a,
+            config = consumer_a_cb_config,
+        }
+
+        local get_and_assert = function (res_status_to_be_generated, res_status_expected, put_delay, api_key, path)
             local proxy_client = helpers.proxy_client()
+            local headers = {
+                response_http_code = res_status_to_be_generated,
+                put_delay = put_delay or 0,
+            }
+            
+            -- Add API key for consumer authentication if provided
+            if api_key then
+                headers["apikey"] = api_key
+            end
+
+            if path then
+                path = path
+            else
+                path = "/test"
+            end
+            
             local res = assert(
                 proxy_client:send({
                     method = "GET",
-                    path = "/test",
-                    headers = {
-                        response_http_code = res_status_to_be_generated,
-                        put_delay = put_delay or 0,
-                    },
+                    path = path,
+                    headers = headers,
                 }))
             assert.are.same(res_status_expected, res.status)
             proxy_client:close()
         end
 
-        local update_plugin = function(config, enabled)
+        local update_plugin = function(plugin_id, config, enabled)
             local admin_client = helpers.admin_client()
-            local url = "/plugins/" .. circuit_breaker_plugin["id"]
+            local url = "/plugins/" .. plugin_id
 
             local admin_res = assert(
                 admin_client:patch(url, {
@@ -86,7 +159,18 @@ for _, strategy in ipairs(strategies) do
                         enabled = enabled,
                     },
                 }))
-            assert.res_status(200, admin_res)
+            assert.equal(200, admin_res.status)
+            admin_client:close()
+        end
+
+        local disable_plugin = function(plugin_id)
+            local admin_client = helpers.admin_client()
+            local url = "/plugins/" .. plugin_id
+            local admin_res = assert(admin_client:patch(url, {
+                headers = {["Content-Type"] = "application/json"},
+                body = {enabled = false},
+            }))
+            assert.equal(200, admin_res.status)
             admin_client:close()
         end
 
@@ -94,7 +178,7 @@ for _, strategy in ipairs(strategies) do
             print("setting up")
             assert(helpers.start_kong({
                 database = strategy,
-                plugins = "circuit-breaker",
+                plugins = "circuit-breaker,key-auth",
                 nginx_conf = "spec/fixtures/custom_nginx.template"
             }, nil, nil, fixtures.fixtures))
         end)
@@ -105,7 +189,8 @@ for _, strategy in ipairs(strategies) do
 
         before_each(function ()
             print("updating config")
-            update_plugin(default_config)
+            update_plugin(circuit_breaker_plugin["id"], default_config, true)
+            update_plugin(consumer_a_cb_plugin["id"], consumer_a_cb_config, true)
         end)
 
         -- after_each(function ()
@@ -211,7 +296,7 @@ for _, strategy in ipairs(strategies) do
                 get_and_assert(200, cb_error_status_code)
             end
             local new_cb_error_status_code = 598
-            update_plugin({error_status_code = new_cb_error_status_code})
+            update_plugin(circuit_breaker_plugin["id"], {error_status_code = new_cb_error_status_code})
             get_and_assert(200, 200)
             for _ = 1, min_calls_in_window - 1 , 1 do
                 get_and_assert(200, 504, 1)
@@ -220,12 +305,12 @@ for _, strategy in ipairs(strategies) do
                 get_and_assert(200, new_cb_error_status_code)
             end
             finally(function ()
-                update_plugin({error_status_code = cb_error_status_code})
+                update_plugin(circuit_breaker_plugin["id"], {error_status_code = cb_error_status_code})
             end)
         end)
 
         it("should not create circuit breakers for excluded apis", function()
-            update_plugin({excluded_apis = "{\"GET_/test\": true}"})
+            update_plugin(circuit_breaker_plugin["id"], {excluded_apis = "{\"GET_/test\": true}"})
             get_and_assert(200, 200)
             for _ = 1, min_calls_in_window + 10 , 1 do
                 get_and_assert(500, 500)
@@ -243,13 +328,30 @@ for _, strategy in ipairs(strategies) do
             get_and_assert(504, 504, 0.5)
 
             -- Disable plugin
-            update_plugin(default_config, false)
+            disable_plugin(circuit_breaker_plugin["id"])
 
             -- Call taking time t where, api_call_timeout of disable plugin < t < service timeout should succeed
             get_and_assert(200, 200, 0.5)
 
             -- Call taking time t where, api_call_timeout of disable plugin < service timeout < t should fail
             get_and_assert(504, 504, 1.5)
+        end)
+
+
+        it("should use consumer-specific circuit breaker plugin if consumer is authenticated", function()
+            for _ = 1, min_calls_in_window , 1 do
+                get_and_assert(500, 500, 0, "key_a", "/test2")
+            end
+            get_and_assert(200, 598, 0, "key_a", "/test2")
+            get_and_assert(200, 200, 0, "key_b", "/test2")
+            get_and_assert(200, 200, 0)
+        end)
+
+        it("should open global circuit breaker if circuit breaker plugin is not enabled for consumer", function()
+            for _ = 1, min_calls_in_window, 1 do
+                get_and_assert(500, 500, 0, "key_b", "/test2")
+            end
+            get_and_assert(200, 599, 0, "key_b", "/test2")
         end)
 
         --  This test case can't be tested as requests to really get stuck, we can't use ngx.sleep() in fixtures

--- a/spec/circuit-breaker/fixtures.lua
+++ b/spec/circuit-breaker/fixtures.lua
@@ -28,6 +28,24 @@ _M.fixtures = {
                     return ngx.exit(0)
                 }
             }
+            
+            location = "/test2" {
+                content_by_lua_block {
+                    print("nginx worker id : ")
+                    print(ngx.worker.id())
+
+                    local request_headers = ngx.req.get_headers()
+
+                    if request_headers["put_delay"] then
+                        ngx.sleep(tonumber(request_headers["put_delay"]))
+                    end
+
+                    ngx.status = tonumber(request_headers["response_http_code"])
+
+                    ngx.say("success")
+                    return ngx.exit(0)
+                }
+            }
         }
   ]]
   },


### PR DESCRIPTION
### Summary

This pull request introduces changes to the `circuit-breaker` plugin in Kong to add support for consumer-specific circuit breakers. The updates ensure that circuit breakers can now be scoped not only globally, by service, or by route, but also by consumer. Below is a summary of the most important changes grouped by theme.

### Consumer-specific circuit breaker logic:

- **`kong/plugins/circuit-breaker/handler.lua`:** Updated the `get_circuit_breaker` function to include the consumer ID in the circuit breaker key if a consumer is present. This allows circuit breakers to be scoped by consumer.
- **`kong/plugins/circuit-breaker/handler.lua`:** Modified the `init_worker` function to handle consumer-specific circuit breaker groups by introducing a prefix (`consumer_id`) to the group key. Updated logic to invalidate cache keys with the consumer ID included.
- **`kong/plugins/circuit-breaker/helpers.lua`:** Updated the `get_excluded_apis` function to include the consumer ID in the cache key used for retrieving excluded APIs, ensuring consumer-specific exclusions are supported.

### Schema updates:

- **`kong/plugins/circuit-breaker/schema.lua`:** Removed the `consumer` field from the schema, as consumer-specific circuit breakers are now handled dynamically in the plugin logic without requiring explicit configuration in the schema.
